### PR TITLE
Change the name of init callback event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
-- Added a callback event that gets fired once the library has been properly initialised, to let addons know they can start using the library's SwingTimerInfo endpoint.
+- Added a callback event that gets fired once the library has been properly initialised, to let addons know they can start using the library's SwingTimerInfo method.
 
 ## [1.3.2] - 2022-09-10
 

--- a/LibClassicSwingTimerAPI.lua
+++ b/LibClassicSwingTimerAPI.lua
@@ -27,14 +27,6 @@ local reset_ranged_swing = nil
 
 lib.callbacks = lib.callbacks or LibStub("CallbackHandler-1.0"):New(lib)
 
-lib.SWING_TIMER_INFO_INITIALIZED = "SWING_TIMER_INFO_INITIALIZED"
-lib.SWING_TIMER_START = "SWING_TIMER_START"
-lib.SWING_TIMER_UPDATE = "SWING_TIMER_UPDATE"
-lib.SWING_TIMER_DELTA = "SWING_TIMER_DELTA"
-lib.SWING_TIMER_CLIPPED = "SWING_TIMER_CLIPPED"
-lib.SWING_TIMER_PAUSED = "SWING_TIMER_PAUSED"
-lib.SWING_TIMER_STOP = "SWING_TIMER_STOP"
-
 function lib:Fire(event, ...)
 	self.callbacks:Fire(event, ...)
 end
@@ -78,12 +70,12 @@ function lib:PLAYER_ENTERING_WORLD()
 	self.skipNextAttackSpeedUpdate = nil
 	self.skipNextAttackSpeedUpdateCount = 0
 
-	self.callbacks:Fire(self.SWING_TIMER_INFO_INITIALIZED)
+	self.callbacks:Fire("SWING_TIMER_INFO_INITIALIZED")
 end
 
 function lib:CalculateDelta()
 	if self.offSpeed > 0 and self.mainExpirationTime ~= nil and self.offExpirationTime ~= nil then
-		self:Fire(lib.SWING_TIMER_DELTA, self.mainExpirationTime - self.offExpirationTime)
+		self:Fire("SWING_TIMER_DELTA", self.mainExpirationTime - self.offExpirationTime)
 	end
 end
 
@@ -96,7 +88,7 @@ function lib:SwingStart(hand, startTime, isReset)
 		local mainSpeed, _ = UnitAttackSpeed("player")
 		self.mainSpeed = mainSpeed
 		self.mainExpirationTime = self.lastMainSwing + self.mainSpeed
-		self:Fire(lib.SWING_TIMER_START, self.mainSpeed, self.mainExpirationTime, hand)
+		self:Fire("SWING_TIMER_START", self.mainSpeed, self.mainExpirationTime, hand)
 		if self.mainSpeed > 0 and self.mainExpirationTime - GetTime() > 0 then
 			self.mainTimer = C_Timer.NewTimer(self.mainExpirationTime - GetTime(), function()
 				self:SwingEnd("mainhand")
@@ -116,9 +108,9 @@ function lib:SwingStart(hand, startTime, isReset)
 		if self.offSpeed > 0 and self.firstOffSwing == false and self.isAttacking then
 			self.offExpirationTime = self.lastOffSwing + (self.offSpeed / 2)
 			self:CalculateDelta()
-			self:Fire(lib.SWING_TIMER_UPDATE, self.offSpeed, self.offExpirationTime, hand)
+			self:Fire("SWING_TIMER_UPDATE", self.offSpeed, self.offExpirationTime, hand)
 		elseif self.offSpeed > 0 then
-			self:Fire(lib.SWING_TIMER_START, self.offSpeed, self.offExpirationTime, hand)
+			self:Fire("SWING_TIMER_START", self.offSpeed, self.offExpirationTime, hand)
 			self.calculaDeltaTimer = C_Timer.NewTimer(self.offSpeed / 2, function()
 				self:CalculateDelta()
 			end)
@@ -137,7 +129,7 @@ function lib:SwingStart(hand, startTime, isReset)
 			self.rangedSpeed = self.rangedSpeed
 			self.lastRangedSwing = startTime
 			self.rangedExpirationTime = self.lastRangedSwing + self.rangedSpeed
-			self:Fire(lib.SWING_TIMER_START, self.rangedSpeed, self.rangedExpirationTime, hand)
+			self:Fire("SWING_TIMER_START", self.rangedSpeed, self.rangedExpirationTime, hand)
 			if self.rangedExpirationTime - GetTime() > 0 then
 				self.rangedTimer = C_Timer.NewTimer(self.rangedExpirationTime - GetTime(), function()
 					self:SwingEnd("ranged")
@@ -148,15 +140,15 @@ function lib:SwingStart(hand, startTime, isReset)
 end
 
 function lib:SwingEnd(hand)
-	self:Fire(lib.SWING_TIMER_STOP, hand)
+	self:Fire("SWING_TIMER_STOP", hand)
 	if (self.casting or self.channeling) and self.isAttacking and hand ~= "ranged" then
 		local now = GetTime()
 		if isRetail and hand == "mainhand" then		
 			self:SwingStart(hand, now, true)
-			self:Fire(lib.SWING_TIMER_CLIPPED, hand)
+			self:Fire("SWING_TIMER_CLIPPED", hand)
 		elseif isClassicOrBCCOrWrath then
 			self:SwingStart(hand, now, true)
-			self:Fire(lib.SWING_TIMER_CLIPPED, hand)
+			self:Fire("SWING_TIMER_CLIPPED", hand)
 		end
 	end
 end
@@ -217,7 +209,7 @@ function lib:COMBAT_LOG_EVENT_UNFILTERED(_, ts, subEvent, _, sourceGUID, _, _, _
 		else
 			self.mainExpirationTime = swing_timer_reduced_40p
 		end
-		self:Fire(lib.SWING_TIMER_UPDATE, self.mainSpeed, self.mainExpirationTime, "mainhand")
+		self:Fire("SWING_TIMER_UPDATE", self.mainSpeed, self.mainExpirationTime, "mainhand")
 		if self.mainSpeed > 0 and self.mainExpirationTime - GetTime() > 0 then
 			self.mainTimer = C_Timer.NewTimer(self.mainExpirationTime - GetTime(), function()
 				self:SwingEnd("mainhand")
@@ -269,7 +261,7 @@ function lib:UNIT_ATTACK_SPEED()
 		local timeLeft = (self.lastMainSwing + self.mainSpeed - now) * multiplier
 		self.mainSpeed = mainSpeedNew
 		self.mainExpirationTime = now + timeLeft
-		self:Fire(lib.SWING_TIMER_UPDATE, self.mainSpeed, self.mainExpirationTime, "mainhand")
+		self:Fire("SWING_TIMER_UPDATE", self.mainSpeed, self.mainExpirationTime, "mainhand")
 		if self.mainSpeed > 0 and self.mainExpirationTime - GetTime() > 0 then
 			self.mainTimer = C_Timer.NewTimer(self.mainExpirationTime - GetTime(), function()
 				self:SwingEnd("mainhand")
@@ -284,7 +276,7 @@ function lib:UNIT_ATTACK_SPEED()
 		if self.calculaDeltaTimer ~= nil then
 			self.calculaDeltaTimer:Cancel()
 		end
-		self:Fire(lib.SWING_TIMER_UPDATE, self.offSpeed, self.offExpirationTime, "offhand")
+		self:Fire("SWING_TIMER_UPDATE", self.offSpeed, self.offExpirationTime, "offhand")
 		if self.offSpeed > 0 and self.offExpirationTime - GetTime() > 0 then
 			self.offTimer = C_Timer.NewTimer(self.offExpirationTime - GetTime(), function()
 				self:SwingEnd("offhand")
@@ -301,7 +293,7 @@ function lib:UNIT_SPELLCAST_INTERRUPTED_OR_FAILED(_, _, _, spell)
 			if self.mainExpirationTime < GetTime() and self.isAttacking then
 				self.mainExpirationTime = self.mainExpirationTime + self.mainSpeed
 			end
-			self:Fire(lib.SWING_TIMER_UPDATE, self.mainSpeed, self.mainExpirationTime, "mainhand")
+			self:Fire("SWING_TIMER_UPDATE", self.mainSpeed, self.mainExpirationTime, "mainhand")
 			self.mainTimer = C_Timer.NewTimer(self.mainExpirationTime - GetTime(), function()
 				self:SwingEnd("mainhand")
 			end)
@@ -310,7 +302,7 @@ function lib:UNIT_SPELLCAST_INTERRUPTED_OR_FAILED(_, _, _, spell)
 			if self.offExpirationTime < GetTime() and self.isAttacking then
 				self.offExpirationTime = self.offExpirationTime + self.offSpeed
 			end
-			self:Fire(lib.SWING_TIMER_UPDATE, self.offSpeed, self.offExpirationTime, "offhand")
+			self:Fire("SWING_TIMER_UPDATE", self.offSpeed, self.offExpirationTime, "offhand")
 			self.offTimer = C_Timer.NewTimer(self.offExpirationTime - GetTime(), function()
 				self:SwingEnd("offhand")
 			end)
@@ -352,14 +344,14 @@ function lib:UNIT_SPELLCAST_SUCCEEDED(_, _, _, spell)
 		self.pauseSwingTime = nil
 		if self.mainSpeed > 0 then
 			self.mainExpirationTime = self.mainExpirationTime + offset
-			self:Fire(lib.SWING_TIMER_UPDATE, self.mainSpeed, self.mainExpirationTime, "mainhand")
+			self:Fire("SWING_TIMER_UPDATE", self.mainSpeed, self.mainExpirationTime, "mainhand")
 			self.mainTimer = C_Timer.NewTimer(self.mainExpirationTime - now, function()
 				self:SwingEnd("mainhand")
 			end)
 		end
 		if self.offSpeed > 0 then
 			self.offExpirationTime = self.offExpirationTime + offset
-			self:Fire(lib.SWING_TIMER_UPDATE, self.offSpeed, self.offExpirationTime, "offhand")
+			self:Fire("SWING_TIMER_UPDATE", self.offSpeed, self.offExpirationTime, "offhand")
 			self.offTimer = C_Timer.NewTimer(self.offExpirationTime - now, function()
 				self:SwingEnd("offhand")
 			end)
@@ -395,13 +387,13 @@ function lib:UNIT_SPELLCAST_START(_, unit, _, spell)
 		if spell and pause_swing_spells[spell] then
 			self.pauseSwingTime = now
 			if self.mainSpeed > 0 then
-				self:Fire(lib.SWING_TIMER_PAUSED, "mainhand")
+				self:Fire("SWING_TIMER_PAUSED", "mainhand")
 				if self.mainTimer then
 					self.mainTimer:Cancel()
 				end
 			end
 			if self.offSpeed > 0 then
-				self:Fire(lib.SWING_TIMER_PAUSED, "offhand")
+				self:Fire("SWING_TIMER_PAUSED", "offhand")
 				if self.offTimer then
 					self.offTimer:Cancel()
 				end

--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Fired when a weapon or ranged swing ends.
 | ----------- | ----------- |
 | hand | string - the hand that end a swing ("mainhand", "offhand" or "ranged") |
 
+### SWING_TIMER_INFO_INITIALIZED
+
+Fired after the initialization of the lib. The SwingTimerInfo method is only usable after this event.
+
 ### SWING_TIMER_DELTA
 
 Fired when delta calculation between MH and OH update
@@ -85,7 +89,7 @@ Fired when delta calculation between MH and OH update
 
 ### SwingTimerInfo(hand)
 
-Returns the `hand`'s current swing state.
+Returns the `hand`'s current swing state. Can only be used after the SWING_TIMER_INFO_INITIALIZED event.
 
 ```
 speed, expirationTime, lastSwing = SwingTimerInfo(hand)


### PR DESCRIPTION
@hypernormalisation Proposal to change the name of callback event after initialization. SWING_TIMER_READY seem to me confusing to what this event do. It can be miss understanded as swing ready to start. 

I propose to change this event name to SWING_TIMER_INFO_INITIALIZED. I think It is more self explaining.