### PR TITLE
Added check to not prevent attack speed update on form change when th…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Fixed
+- SWING_TIMER_STOP events now always properly trigger after attack speed updates.
+- Druid attack speeds are no longer snapshotted when the druid's form changes when the swing timer bar is full
+- Druid attack speed changes following mid-swing form changes are now correctly reported when the swing ends.
+
 ## [1.4.0] - 2022-09-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
-- Druid attack speeds are no longer snapshotted when the druid's form changes when the swing timer bar is full
+- Druid attack speeds are no longer snapshotted when the druid's form changes when the swing timer is full
 - Druid attack speed changes following mid-swing form changes are now correctly reported when the swing ends.
 - Fix Slam pause. Prevent LUA error when Slam is casting without autoattack toggled on or if auto attack is toggle of during the cast.
 - Fix main and off hand timer cancellation on UNIT_ATTACK_SPEED event. Prevent timer to be cancelled when the UNIT_ATTACK_SPEED is not modify.

--- a/LibClassicSwingTimerAPI.lua
+++ b/LibClassicSwingTimerAPI.lua
@@ -233,7 +233,7 @@ function lib:COMBAT_LOG_EVENT_UNFILTERED(_, ts, subEvent, _, sourceGUID, _, _, _
 		end
 	elseif (subEvent == "SPELL_AURA_APPLIED" or subEvent == "SPELL_AURA_REMOVED") and sourceGUID == self.unitGUID then
 		local spell = amount
-		if spell and prevent_swing_speed_update[spell] then
+		if spell and prevent_swing_speed_update[spell] and (GetTime() < self.mainExpirationTime) then
 			self.skipNextAttackSpeedUpdate = now
 			self.skipNextAttackSpeedUpdateCount = 2
 		end

--- a/LibClassicSwingTimerAPI.lua
+++ b/LibClassicSwingTimerAPI.lua
@@ -151,6 +151,10 @@ end
 function lib:SwingEnd(hand)
 	if hand == "mainhand" then
 		self.mainTimer:Cancel()
+		if self.class == "DRUID" and self.skipNextAttackSpeedUpdate then
+			self.skipNextAttackSpeedUpdate = nil
+			self:UNIT_ATTACK_SPEED()
+		end
 	elseif hand == "offhand" then
 		self.offTimer:Cancel()
 	elseif hand == "ranged" then


### PR DESCRIPTION
…e druid's bar is full

Logic exists in the library at present to snapshot druid's attack speed when a form change occurs, correctly stopping any attack speed update when the druid is mid-swing.

This also locks out attack speed changes for form changes when the druid's swing timer is full, and therefore any attack speed reported by the library until the druid begins attacking with their new form will be wrong/the old form's speed (see attached, where the bar reports the current attack speed on the left of the bar).

Adding a simple check to only trigger the snapshotting when the current time is less than the mainhand expiration time results in form changes while the timer is full correctly triggering attack speed updates in the library.

![image](https://user-images.githubusercontent.com/52763122/193177012-5ef5b256-71cd-4c8a-bec5-c75750a9fd66.png)

