### PR TITLE
moved C_Timer cancellation in the UNIT_ATTACK_SPEED function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Fixed
+- Fix main and off hand timer cancellation on UNIT_ATTACK_SPEED event. Prevent timer to be cancelled when the UNIT_ATTACK_SPEED is not modify.
+
 ## [1.4.0] - 2022-09-26
 
 ### Added

--- a/LibClassicSwingTimerAPI.lua
+++ b/LibClassicSwingTimerAPI.lua
@@ -264,15 +264,12 @@ function lib:UNIT_ATTACK_SPEED()
 		self.skipNextAttackSpeedUpdateCount = self.skipNextAttackSpeedUpdateCount - 1
 		return
 	end
-	if self.mainTimer then
-		self.mainTimer:Cancel()
-	end
-	if self.offTimer then
-		self.offTimer:Cancel()
-	end
 	local mainSpeedNew, offSpeedNew = UnitAttackSpeed("player")
 	offSpeedNew = offSpeedNew or 0
 	if mainSpeedNew > 0 and self.mainSpeed > 0 and mainSpeedNew ~= self.mainSpeed then
+		if self.mainTimer then
+			self.mainTimer:Cancel()
+		end
 		local multiplier = mainSpeedNew / self.mainSpeed
 		local timeLeft = (self.lastMainSwing + self.mainSpeed - now) * multiplier
 		self.mainSpeed = mainSpeedNew
@@ -285,6 +282,9 @@ function lib:UNIT_ATTACK_SPEED()
 		end
 	end
 	if offSpeedNew > 0 and self.offSpeed > 0 and offSpeedNew ~= self.offSpeed then
+		if self.offTimer then
+			self.offTimer:Cancel()
+		end
 		local multiplier = offSpeedNew / self.offSpeed
 		local timeLeft = (self.lastOffSwing + self.offSpeed - now) * multiplier
 		self.offSpeed = offSpeedNew


### PR DESCRIPTION
Cancellations are now in the code block that checks for a valid attack speed change, to avoid cancelling timers when no new timer is going to be set.

This should ensure every START event gets a STOP event even through attack speed changes.