### PR TITLE
Fix druid weapon speeds when casting spells that unshift them

### DIFF
--- a/LibClassicSwingTimerAPI.lua
+++ b/LibClassicSwingTimerAPI.lua
@@ -492,6 +492,8 @@ function lib:UNIT_SPELLCAST_SUCCEEDED(_, unitType, _, spell)
 	if (spell and reset_swing_spells[spell]) or (unit.casting and not unit.preventSwingReset) then
 		if isRetail then		
 			unit:SwingStart("mainhand", now, true)
+		elseif unit.class == "DRUID" then
+			C_Timer.After(0, function() unit:SwingStart("mainhand", now, true) end)
 		else
 			unit:SwingStart("mainhand", now, true)
 			unit:SwingStart("offhand", now, true)


### PR DESCRIPTION
Implements the proposed solution for #44 
This waits for the spellcast event to resolve before calling unit:SwingStart, so an accurate swing speed and expiration time can be sent with SWING_TIMER_START after druids cast a spell which unshifts them.