### PR TITLE
Allow ADDON_LOADED to process when loaded as embedded library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Fixed
+- Fix lib:ADDON_LOADED function. Allows lib:ADDON_LOADED to correctly initialize when another addon embeds the library.
+
 ## [2.0.1] - 2023-01-18
 
 ### Fixed

--- a/LibClassicSwingTimerAPI.lua
+++ b/LibClassicSwingTimerAPI.lua
@@ -1,3 +1,5 @@
+-- Get the name of a) this addon loaded seperately, or b) the addon that loaded this as an embedded library
+local loadedAddonName = ... 
 local MAJOR, MINOR = "LibClassicSwingTimerAPI", 16
 local lib = LibStub:NewLibrary(MAJOR, MINOR)
 if not lib then
@@ -210,7 +212,8 @@ function lib:UnitSwingTimerInfo(unitId, hand)
 end
 
 function lib:ADDON_LOADED(_, addOnName)
-	if addOnName ~= MAJOR then
+	-- Check to see if this is the addon that loaded the library
+	if addOnName ~= loadedAddonName then
 		return
 	end
 


### PR DESCRIPTION
Currently, if the addon is loaded as an embedded library, ADDON_LOADED does not fire with the name of LibClassicSwingTimerAPI as the game considers the library to be loaded as part of the parent addon.

This causes problems as `self.player` and `self.target` are only initialized in `lib:ADDON_LOADED` for version 2.0.1, so upon any CLEU events (or addons attempting to access the API), many lua errors are generated.

This PR reads the name of the addon which had loaded `LibClassicSwingTimerApi.lua` and allows `lib:ADDON_LOADED` to correctly initialize when another addon embeds the library.

After these changes, the addon works properly as an embedded library.